### PR TITLE
Added support for VS Code Remote-Containers extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ which of the currently open tabs will be reloaded when saving. That's it. Next
 time you save a file, that tab will reload.
 
 If you want to stop reloading, run the command `Auto Reload: stop`.
+
+Remote Development Environments
+-----
+The extension runs locally in the UI environment so is automatically fully compatible with VS Code's Remote Development options provided the browser is on the same machine as the VS Code UI interface.

--- a/package.json
+++ b/package.json
@@ -59,5 +59,6 @@
 	},
 	"dependencies": {
 		"chrome-remote-interface": "^0.28.2"
-	}
+	},
+	"extensionKind": ["ui"]
 }


### PR DESCRIPTION
When running with a remote development environment the extension defaults to running in the VS Code Server on the remote container/server, this prevents it from connecting with the local browser. This change forces the extension to run in the VS UI environment rather than the server environment inside the container.