### PR TITLE
Added delay&refactored settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ which of the currently open tabs will be reloaded when saving. That's it. Next
 time you save a file, that tab will reload.
 
 If you want to stop reloading, run the command `Auto Reload: stop`.
+
+
+Configuration
+-----
+Host - Host settings for connections are configurable in extension settings. *Please note most browsers require extra configuration for (or in the case of Chrome seem not to allow at all) connections from remote machines, although workarounds do exist.*

--- a/README.md
+++ b/README.md
@@ -31,4 +31,5 @@ If you want to stop reloading, run the command `Auto Reload: stop`.
 
 Configuration
 -----
+Delay - It is possible to delay the reload by a specified amount to allow for any upload/build times that occur after save.
 Host - Host settings for connections are configurable in extension settings. *Please note most browsers require extra configuration for (or in the case of Chrome seem not to allow at all) connections from remote machines, although workarounds do exist.*

--- a/extension.js
+++ b/extension.js
@@ -28,12 +28,18 @@ function request(obj = {}) {
     "secure": config.secure
   }, obj);
 }
+// Helper method to allow sleep
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 const reload = debounce(async () => {
   if (currentTarget === null) return;
   console.log("RELOAD");
 
   const client = await CDP(request({target: currentTarget}));
+  // Sleep for the requested delay time
+  await sleep(config.delay);
   client.Page.reload();
 }, 100);
 

--- a/extension.js
+++ b/extension.js
@@ -38,8 +38,7 @@ const reload = debounce(async () => {
 }, 100);
 
 function activate(context) {
-  config = vscode.workspace.getConfiguration("simpleautoreload");
-
+  config = vscode.workspace.getConfiguration("vscode-simple-auto-reload");
   context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(
     async _doc => {
       console.log("SAVE");

--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
 					"type": "boolean",
 					"description": "DevTools remote use HTTPS",
 					"default": false
+				},
+				"vscode-simple-auto-reload.delay": {
+					"type": "number",
+					"description": "Delay reload after save (ms)",
+					"default": 100
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -14,28 +14,22 @@
 	"main": "./extension.js",
 	"contributes": {
 		"configuration": {
-			"title": "Auto reload command configuration.",
-			"type": "object",
+			"title": "Simple Auto Reload",
 			"properties": {
-				"simpleautoreload": {
-					"type": "object",
-					"properties": {
-						"host": {
-							"type": "string",
-							"description": "DevTools remote host",
-							"default": "localhost"
-						},
-						"port": {
-							"type": "integer",
-							"description": "DevTools remote port",
-							"default": 9222
-						},
-						"secure": {
-							"type": "boolean",
-							"description": "DevTools remote use HTTPS",
-							"default": false
-						}
-					}
+				"vscode-simple-auto-reload.host": {
+					"type": "string",
+					"description": "DevTools remote host",
+					"default": "localhost"
+				},
+				"vscode-simple-auto-reload.port": {
+					"type": "integer",
+					"description": "DevTools remote port",
+					"default": 9222
+				},
+				"vscode-simple-auto-reload.secure": {
+					"type": "boolean",
+					"description": "DevTools remote use HTTPS",
+					"default": false
 				}
 			}
 		},


### PR DESCRIPTION
_Apologies about rolling two changes and commits into one pull request, couldn't see another option given their interdependence._

The previous format of the settings object prevented editing in the settings GUI, this update allows for that easier editing.

Delay option provides time for any build/upload actions that may need to occur before the browser reloads. Setting is editable in the settings GUI.